### PR TITLE
chore: replace bitnami image references with soldevelo equivalents

### DIFF
--- a/src/containers/bitnami/airflow/3/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/airflow/3/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:
@@ -13,7 +13,7 @@ services:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes
   redis:
-    image: docker.io/bitnami/redis:latest
+    image: docker.io/soldevelo/redis:latest
     volumes:
       - 'redis_data:/bitnami'
     environment:

--- a/src/containers/bitnami/airflow/docker-compose-ldap.yml
+++ b/src/containers/bitnami/airflow/docker-compose-ldap.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:
@@ -12,7 +12,7 @@ services:
       - POSTGRESQL_PASSWORD=bitnami1
       - ALLOW_EMPTY_PASSWORD=yes
   redis:
-    image: docker.io/bitnami/redis:latest
+    image: docker.io/soldevelo/redis:latest
     volumes:
       - 'redis_data:/bitnami'
     environment:

--- a/src/containers/bitnami/airflow/docker-compose.yml
+++ b/src/containers/bitnami/airflow/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:
@@ -13,7 +13,7 @@ services:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes
   redis:
-    image: docker.io/bitnami/redis:latest
+    image: docker.io/soldevelo/redis:latest
     volumes:
       - 'redis_data:/bitnami'
     environment:

--- a/src/containers/bitnami/appsmith/1/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/appsmith/1/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mongodb:
-    image: docker.io/bitnami/mongodb:latest
+    image: docker.io/soldevelo/mongodb:latest
     volumes:
       - 'mongodb_data:/bitnami/mongodb'
     environment:
@@ -16,7 +16,7 @@ services:
       - MONGODB_REPLICA_SET_KEY=replicasetkey123
 
   mongodb-secondary:
-    image: docker.io/bitnami/mongodb:latest
+    image: docker.io/soldevelo/mongodb:latest
     depends_on:
       - mongodb
     volumes:
@@ -28,7 +28,7 @@ services:
       - MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD=password123
       - MONGODB_REPLICA_SET_KEY=replicasetkey123
   redis:
-    image: docker.io/bitnami/redis:latest
+    image: docker.io/soldevelo/redis:latest
     volumes:
       - 'redis_data:/bitnami/redis'
     environment:

--- a/src/containers/bitnami/appsmith/docker-compose.yml
+++ b/src/containers/bitnami/appsmith/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mongodb:
-    image: docker.io/bitnami/mongodb:latest
+    image: docker.io/soldevelo/mongodb:latest
     volumes:
       - 'mongodb_data:/bitnami/mongodb'
     environment:
@@ -16,7 +16,7 @@ services:
       - MONGODB_REPLICA_SET_KEY=replicasetkey123
 
   mongodb-secondary:
-    image: docker.io/bitnami/mongodb:latest
+    image: docker.io/soldevelo/mongodb:latest
     depends_on:
       - mongodb
     volumes:
@@ -28,7 +28,7 @@ services:
       - MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD=password123
       - MONGODB_REPLICA_SET_KEY=replicasetkey123
   redis:
-    image: docker.io/bitnami/redis:latest
+    image: docker.io/soldevelo/redis:latest
     volumes:
       - 'redis_data:/bitnami/redis'
     environment:

--- a/src/containers/bitnami/concourse/7/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/concourse/7/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     environment:
       - POSTGRESQL_DATABASE=bitnami_concourse
       - POSTGRESQL_USERNAME=bn_concourse

--- a/src/containers/bitnami/concourse/docker-compose-testing.yml
+++ b/src/containers/bitnami/concourse/docker-compose-testing.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     environment:
       - POSTGRESQL_DATABASE=bitnami_concourse
       - POSTGRESQL_USERNAME=bn_concourse

--- a/src/containers/bitnami/concourse/docker-compose.yml
+++ b/src/containers/bitnami/concourse/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     environment:
       - POSTGRESQL_DATABASE=bitnami_concourse
       - POSTGRESQL_USERNAME=bn_concourse

--- a/src/containers/bitnami/discourse/3/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/discourse/3/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:
@@ -12,7 +12,7 @@ services:
       - POSTGRESQL_USERNAME=bn_discourse
       - POSTGRESQL_DATABASE=bitnami_discourse
   redis:
-    image: docker.io/bitnami/redis:latest
+    image: docker.io/soldevelo/redis:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/discourse/docker-compose.yml
+++ b/src/containers/bitnami/discourse/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:
@@ -12,7 +12,7 @@ services:
       - POSTGRESQL_USERNAME=bn_discourse
       - POSTGRESQL_DATABASE=bitnami_discourse
   redis:
-    image: docker.io/bitnami/redis:latest
+    image: docker.io/soldevelo/redis:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/drupal/11/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/drupal/11/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/drupal/docker-compose.yml
+++ b/src/containers/bitnami/drupal/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/ejbca/9/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/ejbca/9/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     volumes:
       - "mariadb_data:/bitnami/mariadb"
     environment:

--- a/src/containers/bitnami/ejbca/docker-compose.yml
+++ b/src/containers/bitnami/ejbca/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     volumes:
       - "mariadb_data:/bitnami/mariadb"
     environment:

--- a/src/containers/bitnami/express/5/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/express/5/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mongodb:
-    image: docker.io/bitnami/mongodb:latest
+    image: docker.io/soldevelo/mongodb:latest
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
   express:

--- a/src/containers/bitnami/express/docker-compose-mariadb.yml
+++ b/src/containers/bitnami/express/docker-compose-mariadb.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
       - MARIADB_DATABASE=myapp

--- a/src/containers/bitnami/express/docker-compose-postgresql.yml
+++ b/src/containers/bitnami/express/docker-compose-postgresql.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     environment:
       - POSTGRESQL_DATABASE=myapp
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/express/docker-compose.yml
+++ b/src/containers/bitnami/express/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mongodb:
-    image: docker.io/bitnami/mongodb:latest
+    image: docker.io/soldevelo/mongodb:latest
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
   express:

--- a/src/containers/bitnami/gitea/1/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/gitea/1/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:

--- a/src/containers/bitnami/gitea/docker-compose.yml
+++ b/src/containers/bitnami/gitea/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:

--- a/src/containers/bitnami/harbor-portal/2/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/harbor-portal/2/debian-12/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       - jobservice_data:/var/log/jobs
       - ./config/jobservice/config.yml:/etc/jobservice/config.yml:ro
   redis:
-    image: docker.io/bitnami/redis:latest
+    image: docker.io/soldevelo/redis:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/harbor-portal/docker-compose.yml
+++ b/src/containers/bitnami/harbor-portal/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       - jobservice_data:/var/log/jobs
       - ./config/jobservice/config.yml:/etc/jobservice/config.yml:ro
   redis:
-    image: docker.io/bitnami/redis:latest
+    image: docker.io/soldevelo/redis:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/kafka/4.0/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/kafka/4.0/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   kafka:
-    image: docker.io/bitnami/kafka:4.0
+    image: docker.io/soldevelo/kafka:4.0
     ports:
       - "9092:9092"
     volumes:

--- a/src/containers/bitnami/kafka/docker-compose-cluster.yml
+++ b/src/containers/bitnami/kafka/docker-compose-cluster.yml
@@ -3,7 +3,7 @@
 
 services:
   kafka-0:
-    image: docker.io/bitnami/kafka:4.0
+    image: docker.io/soldevelo/kafka:4.0
     ports:
       - "9092"
     environment:
@@ -25,7 +25,7 @@ services:
     volumes:
       - kafka_0_data:/bitnami/kafka
   kafka-1:
-    image: docker.io/bitnami/kafka:4.0
+    image: docker.io/soldevelo/kafka:4.0
     ports:
       - "9092"
     environment:
@@ -47,7 +47,7 @@ services:
     volumes:
       - kafka_1_data:/bitnami/kafka
   kafka-2:
-    image: docker.io/bitnami/kafka:4.0
+    image: docker.io/soldevelo/kafka:4.0
     ports:
       - "9092"
     environment:

--- a/src/containers/bitnami/kafka/docker-compose.yml
+++ b/src/containers/bitnami/kafka/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   kafka:
-    image: docker.io/bitnami/kafka:4.0
+    image: docker.io/soldevelo/kafka:4.0
     ports:
       - "9092:9092"
     volumes:

--- a/src/containers/bitnami/keycloak/26/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/keycloak/26/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/keycloak/docker-compose.yml
+++ b/src/containers/bitnami/keycloak/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/kong/3/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/kong/3/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - postgresql_data:/bitnami/postgresql
     environment:

--- a/src/containers/bitnami/kong/docker-compose-cluster.yml
+++ b/src/containers/bitnami/kong/docker-compose-cluster.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     ports:
       - '5432'
     volumes:

--- a/src/containers/bitnami/kong/docker-compose.yml
+++ b/src/containers/bitnami/kong/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - postgresql_data:/bitnami/postgresql
     environment:

--- a/src/containers/bitnami/mastodon/4/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/mastodon/4/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:
@@ -11,7 +11,7 @@ services:
       - POSTGRESQL_USERNAME=bn_mastodon
       - POSTGRESQL_PASSWORD=bitnami1
   redis:
-    image: docker.io/bitnami/redis:latest
+    image: docker.io/soldevelo/redis:latest
     volumes:
       - 'redis_data:/bitnami/redis'
     environment:

--- a/src/containers/bitnami/mastodon/docker-compose.yml
+++ b/src/containers/bitnami/mastodon/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:
@@ -11,7 +11,7 @@ services:
       - POSTGRESQL_USERNAME=bn_mastodon
       - POSTGRESQL_PASSWORD=bitnami1
   redis:
-    image: docker.io/bitnami/redis:latest
+    image: docker.io/soldevelo/redis:latest
     volumes:
       - 'redis_data:/bitnami/redis'
     environment:

--- a/src/containers/bitnami/matomo/5/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/matomo/5/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/matomo/docker-compose.yml
+++ b/src/containers/bitnami/matomo/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/minio/docker-compose-distributed-multidrive.yml
+++ b/src/containers/bitnami/minio/docker-compose-distributed-multidrive.yml
@@ -3,7 +3,7 @@
 
 services:
   prepare-data:
-    image: 'docker.io/bitnami/os-shell:latest'
+    image: 'docker.io/soldevelo/os-shell:latest'
     user: root
     command:
       - /bin/bash

--- a/src/containers/bitnami/moodle/5.0/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/moodle/5.0/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/moodle/docker-compose.yml
+++ b/src/containers/bitnami/moodle/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/odoo/18/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/odoo/18/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:

--- a/src/containers/bitnami/odoo/docker-compose.yml
+++ b/src/containers/bitnami/odoo/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:

--- a/src/containers/bitnami/parse/8/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/parse/8/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mongodb:
-    image: docker.io/bitnami/mongodb:latest
+    image: docker.io/soldevelo/mongodb:latest
     volumes:
       - 'mongodb_data:/bitnami/mongodb'
     environment:

--- a/src/containers/bitnami/parse/docker-compose.yml
+++ b/src/containers/bitnami/parse/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mongodb:
-    image: docker.io/bitnami/mongodb:latest
+    image: docker.io/soldevelo/mongodb:latest
     volumes:
       - 'mongodb_data:/bitnami/mongodb'
     environment:

--- a/src/containers/bitnami/pgbouncer/1/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/pgbouncer/1/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:

--- a/src/containers/bitnami/pgbouncer/docker-compose-password.yml
+++ b/src/containers/bitnami/pgbouncer/docker-compose-password.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:

--- a/src/containers/bitnami/pgbouncer/docker-compose.yml
+++ b/src/containers/bitnami/pgbouncer/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:

--- a/src/containers/bitnami/pgpool/4/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/pgpool/4/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   pg-0:
-    image: docker.io/bitnami/postgresql-repmgr:latest
+    image: docker.io/soldevelo/postgresql-repmgr:latest
     ports:
       - 5432
     volumes:
@@ -39,7 +39,7 @@ services:
       - REPMGR_USERNAME=repmgr
       - REPMGR_PASSWORD=repmgrpassword
   pgpool:
-    image: docker.io/bitnami/pgpool:4
+    image: docker.io/soldevelo/pgpool:4
     ports:
       - 5432:5432
     environment:

--- a/src/containers/bitnami/pgpool/docker-compose-ldap.yml
+++ b/src/containers/bitnami/pgpool/docker-compose-ldap.yml
@@ -3,7 +3,7 @@
 
 services:
   pg-0:
-    image: docker.io/bitnami/postgresql-repmgr:latest
+    image: docker.io/soldevelo/postgresql-repmgr:latest
     ports:
       - 5432
     volumes:
@@ -39,7 +39,7 @@ services:
       - REPMGR_USERNAME=repmgr
       - REPMGR_PASSWORD=repmgrpassword
   pgpool:
-    image: docker.io/bitnami/pgpool:4
+    image: docker.io/soldevelo/pgpool:4
     ports:
       - 5432:5432
     environment:

--- a/src/containers/bitnami/pgpool/docker-compose.yml
+++ b/src/containers/bitnami/pgpool/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   pg-0:
-    image: docker.io/bitnami/postgresql-repmgr:latest
+    image: docker.io/soldevelo/postgresql-repmgr:latest
     ports:
       - 5432
     volumes:
@@ -39,7 +39,7 @@ services:
       - REPMGR_USERNAME=repmgr
       - REPMGR_PASSWORD=repmgrpassword
   pgpool:
-    image: docker.io/bitnami/pgpool:4
+    image: docker.io/soldevelo/pgpool:4
     ports:
       - 5432:5432
     environment:

--- a/src/containers/bitnami/phpmyadmin/5/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/phpmyadmin/5/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     environment:
       - MARIADB_ROOT_PASSWORD=bitnami
     volumes:

--- a/src/containers/bitnami/phpmyadmin/docker-compose.yml
+++ b/src/containers/bitnami/phpmyadmin/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     environment:
       - MARIADB_ROOT_PASSWORD=bitnami
     volumes:

--- a/src/containers/bitnami/postgresql-repmgr/17/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/postgresql-repmgr/17/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   pg-0:
-    image: docker.io/bitnami/postgresql-repmgr:17
+    image: docker.io/soldevelo/postgresql-repmgr:17
     ports:
       - 5432
     volumes:
@@ -21,7 +21,7 @@ services:
       - REPMGR_NODE_NETWORK_NAME=pg-0
       - REPMGR_PORT_NUMBER=5432
   pg-1:
-    image: docker.io/bitnami/postgresql-repmgr:17
+    image: docker.io/soldevelo/postgresql-repmgr:17
     ports:
       - 5432
     volumes:

--- a/src/containers/bitnami/postgresql-repmgr/docker-compose.yml
+++ b/src/containers/bitnami/postgresql-repmgr/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   pg-0:
-    image: docker.io/bitnami/postgresql-repmgr:17
+    image: docker.io/soldevelo/postgresql-repmgr:17
     ports:
       - 5432
     volumes:
@@ -21,7 +21,7 @@ services:
       - REPMGR_NODE_NETWORK_NAME=pg-0
       - REPMGR_PORT_NUMBER=5432
   pg-1:
-    image: docker.io/bitnami/postgresql-repmgr:17
+    image: docker.io/soldevelo/postgresql-repmgr:17
     ports:
       - 5432
     volumes:

--- a/src/containers/bitnami/rabbitmq/4.1/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/rabbitmq/4.1/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   rabbitmq:
-    image: docker.io/bitnami/rabbitmq:4.1
+    image: docker.io/soldevelo/rabbitmq:4.1
     ports:
       - '4369:4369'
       - '5551:5551'

--- a/src/containers/bitnami/rabbitmq/docker-compose-cluster.yml
+++ b/src/containers/bitnami/rabbitmq/docker-compose-cluster.yml
@@ -3,7 +3,7 @@
 
 services:
   stats:
-    image: docker.io/bitnami/rabbitmq:4.1
+    image: docker.io/soldevelo/rabbitmq:4.1
     environment:
       - RABBITMQ_NODE_TYPE=stats
       - RABBITMQ_NODE_NAME=rabbit@stats
@@ -15,7 +15,7 @@ services:
     volumes:
       - 'rabbitmqstats_data:/bitnami/rabbitmq/mnesia'
   queue-disc1:
-    image: docker.io/bitnami/rabbitmq:4.1
+    image: docker.io/soldevelo/rabbitmq:4.1
     environment:
       - RABBITMQ_NODE_TYPE=queue-disc
       - RABBITMQ_NODE_NAME=rabbit@queue-disc1
@@ -26,7 +26,7 @@ services:
     volumes:
       - 'rabbitmqdisc1_data:/bitnami/rabbitmq/mnesia'
   queue-ram1:
-    image: docker.io/bitnami/rabbitmq:4.1
+    image: docker.io/soldevelo/rabbitmq:4.1
     environment:
       - RABBITMQ_NODE_TYPE=queue-ram
       - RABBITMQ_NODE_NAME=rabbit@queue-ram1

--- a/src/containers/bitnami/rabbitmq/docker-compose-ldap.yml
+++ b/src/containers/bitnami/rabbitmq/docker-compose-ldap.yml
@@ -3,7 +3,7 @@
 
 services:
   rabbitmq:
-    image: docker.io/bitnami/rabbitmq:4.1
+    image: docker.io/soldevelo/rabbitmq:4.1
     ports:
       - '4369:4369'
       - '5551:5551'

--- a/src/containers/bitnami/rabbitmq/docker-compose.yml
+++ b/src/containers/bitnami/rabbitmq/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   rabbitmq:
-    image: docker.io/bitnami/rabbitmq:4.1
+    image: docker.io/soldevelo/rabbitmq:4.1
     ports:
       - '4369:4369'
       - '5551:5551'

--- a/src/containers/bitnami/rails/8/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/rails/8/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/rails/docker-compose-testing.yml
+++ b/src/containers/bitnami/rails/docker-compose-testing.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/rails/docker-compose.yml
+++ b/src/containers/bitnami/rails/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/redmine/6/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/redmine/6/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     volumes:
       - 'mariadb_data:/bitnami/mariadb'
     environment:

--- a/src/containers/bitnami/redmine/docker-compose-postgresql.yml
+++ b/src/containers/bitnami/redmine/docker-compose-postgresql.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:

--- a/src/containers/bitnami/redmine/docker-compose.yml
+++ b/src/containers/bitnami/redmine/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     volumes:
       - 'mariadb_data:/bitnami/mariadb'
     environment:

--- a/src/containers/bitnami/schema-registry/8.0/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/schema-registry/8.0/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   kafka-0:
-    image: docker.io/bitnami/kafka:latest
+    image: docker.io/soldevelo/kafka:latest
     environment:
       # KRaft settings
       - KAFKA_CFG_NODE_ID=0
@@ -19,7 +19,7 @@ services:
     volumes:
       - 'kafka0_data:/bitnami/kafka'
   kafka-1:
-    image: docker.io/bitnami/kafka:latest
+    image: docker.io/soldevelo/kafka:latest
     environment:
       # KRaft settings
       - KAFKA_CFG_NODE_ID=1

--- a/src/containers/bitnami/schema-registry/docker-compose.yml
+++ b/src/containers/bitnami/schema-registry/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   kafka-0:
-    image: docker.io/bitnami/kafka:latest
+    image: docker.io/soldevelo/kafka:latest
     environment:
       # KRaft settings
       - KAFKA_CFG_NODE_ID=0
@@ -19,7 +19,7 @@ services:
     volumes:
       - 'kafka0_data:/bitnami/kafka'
   kafka-1:
-    image: docker.io/bitnami/kafka:latest
+    image: docker.io/soldevelo/kafka:latest
     environment:
       # KRaft settings
       - KAFKA_CFG_NODE_ID=1

--- a/src/containers/bitnami/sonarqube/25/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/sonarqube/25/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:

--- a/src/containers/bitnami/sonarqube/docker-compose.yml
+++ b/src/containers/bitnami/sonarqube/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:

--- a/src/containers/bitnami/suitecrm/8/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/suitecrm/8/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/suitecrm/docker-compose.yml
+++ b/src/containers/bitnami/suitecrm/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     environment:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes

--- a/src/containers/bitnami/wordpress-nginx/6/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/wordpress-nginx/6/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     volumes:
       - 'mariadb_data:/bitnami/mariadb'
     environment:

--- a/src/containers/bitnami/wordpress-nginx/docker-compose.yml
+++ b/src/containers/bitnami/wordpress-nginx/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     volumes:
       - 'mariadb_data:/bitnami/mariadb'
     environment:

--- a/src/containers/bitnami/wordpress/6/debian-12/docker-compose.yml
+++ b/src/containers/bitnami/wordpress/6/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     volumes:
       - 'mariadb_data:/bitnami/mariadb'
     environment:

--- a/src/containers/bitnami/wordpress/docker-compose.yml
+++ b/src/containers/bitnami/wordpress/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   mariadb:
-    image: docker.io/bitnami/mariadb:latest
+    image: docker.io/soldevelo/mariadb:latest
     volumes:
       - 'mariadb_data:/bitnami/mariadb'
     environment:

--- a/src/containers/firestream/airflow/3/debian-12/docker-compose.yml
+++ b/src/containers/firestream/airflow/3/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:
@@ -13,7 +13,7 @@ services:
       # ALLOW_EMPTY_PASSWORD is recommended only for development.
       - ALLOW_EMPTY_PASSWORD=yes
   redis:
-    image: docker.io/bitnami/redis:latest
+    image: docker.io/soldevelo/redis:latest
     volumes:
       - 'redis_data:/bitnami'
     environment:

--- a/src/containers/firestream/airflow/docker-compose-ldap.yml
+++ b/src/containers/firestream/airflow/docker-compose-ldap.yml
@@ -3,7 +3,7 @@
 
 services:
   postgresql:
-    image: docker.io/bitnami/postgresql:latest
+    image: docker.io/soldevelo/postgresql:latest
     volumes:
       - 'postgresql_data:/bitnami/postgresql'
     environment:
@@ -12,7 +12,7 @@ services:
       - POSTGRESQL_PASSWORD=bitnami1
       - ALLOW_EMPTY_PASSWORD=yes
   redis:
-    image: docker.io/bitnami/redis:latest
+    image: docker.io/soldevelo/redis:latest
     volumes:
       - 'redis_data:/bitnami'
     environment:

--- a/src/containers/firestream/kafka/4.0/debian-12/docker-compose.yml
+++ b/src/containers/firestream/kafka/4.0/debian-12/docker-compose.yml
@@ -3,7 +3,7 @@
 
 services:
   kafka:
-    image: docker.io/bitnami/kafka:4.0
+    image: docker.io/soldevelo/kafka:4.0
     ports:
       - "9092:9092"
     volumes:

--- a/src/containers/firestream/kafka/docker-compose-cluster.yml
+++ b/src/containers/firestream/kafka/docker-compose-cluster.yml
@@ -3,7 +3,7 @@
 
 services:
   kafka-0:
-    image: docker.io/bitnami/kafka:4.0
+    image: docker.io/soldevelo/kafka:4.0
     ports:
       - "9092"
     environment:
@@ -25,7 +25,7 @@ services:
     volumes:
       - kafka_0_data:/bitnami/kafka
   kafka-1:
-    image: docker.io/bitnami/kafka:4.0
+    image: docker.io/soldevelo/kafka:4.0
     ports:
       - "9092"
     environment:
@@ -47,7 +47,7 @@ services:
     volumes:
       - kafka_1_data:/bitnami/kafka
   kafka-2:
-    image: docker.io/bitnami/kafka:4.0
+    image: docker.io/soldevelo/kafka:4.0
     ports:
       - "9092"
     environment:

--- a/src/lib/rust/firestream/src/templates/python-selenium-server/docker-compose.yaml
+++ b/src/lib/rust/firestream/src/templates/python-selenium-server/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - ALLOW_ANONYMOUS_LOGIN=yes
 
   kafka:
-    image: docker.io/bitnami/kafka:3.4
+    image: docker.io/soldevelo/kafka:3.4
     ports:
       - "9092:9092"
     volumes:

--- a/src/templates/_example_apps/services/api/webcrawler_server/docker-compose.yaml
+++ b/src/templates/_example_apps/services/api/webcrawler_server/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - ALLOW_ANONYMOUS_LOGIN=yes
 
   kafka:
-    image: docker.io/bitnami/kafka:3.4
+    image: docker.io/soldevelo/kafka:3.4
     ports:
       - "9092:9092"
     volumes:

--- a/src/templates/_example_apps/webcrawler_server/docker-compose.yaml
+++ b/src/templates/_example_apps/webcrawler_server/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - ALLOW_ANONYMOUS_LOGIN=yes
 
   kafka:
-    image: docker.io/bitnami/kafka:3.4
+    image: docker.io/soldevelo/kafka:3.4
     ports:
       - "9092:9092"
     volumes:


### PR DESCRIPTION
## Why this change

Bitnami moved image updates behind a paywall on August 28 2025, and public images no longer receive ongoing updates.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements with active support.

## Image replacements

- `bitnami/kafka:3.4` → [`soldevelo/kafka:3.4`](https://hub.docker.com/r/soldevelo/kafka)
- `bitnami/kafka:4.0` → [`soldevelo/kafka:4.0`](https://hub.docker.com/r/soldevelo/kafka)
- `bitnami/postgresql:latest` → [`soldevelo/postgresql:latest`](https://hub.docker.com/r/soldevelo/postgresql)
- `bitnami/redis:latest` → [`soldevelo/redis:latest`](https://hub.docker.com/r/soldevelo/redis)
- `bitnami/mariadb:latest` → [`soldevelo/mariadb:latest`](https://hub.docker.com/r/soldevelo/mariadb)
- `bitnami/kafka:latest` → [`soldevelo/kafka:latest`](https://hub.docker.com/r/soldevelo/kafka)
- `bitnami/os-shell:latest` → [`soldevelo/os-shell:latest`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/rabbitmq:4.1` → [`soldevelo/rabbitmq:4.1`](https://hub.docker.com/r/soldevelo/rabbitmq)
- `bitnami/postgresql-repmgr:latest` → [`soldevelo/postgresql-repmgr:latest`](https://hub.docker.com/r/soldevelo/postgresql-repmgr)
- `bitnami/pgpool:4` → [`soldevelo/pgpool:4`](https://hub.docker.com/r/soldevelo/pgpool)
- `bitnami/postgresql-repmgr:17` → [`soldevelo/postgresql-repmgr:17`](https://hub.docker.com/r/soldevelo/postgresql-repmgr)
- `bitnami/mongodb:latest` → [`soldevelo/mongodb:latest`](https://hub.docker.com/r/soldevelo/mongodb)